### PR TITLE
Don't swallow errors

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -9,4 +9,17 @@ describe("Benchmark", () => {
   it("should return Promise", () => {
     return new Benchmark().add("foo", noop).add("bar", noop).run();
   });
+
+  it("should catch error", async () => {
+    try {
+      await new Benchmark()
+        .add("foo", () => {
+          throw new Error("foo");
+        })
+        .run();
+      t.fail();
+    } catch (err) {
+      /* noop */
+    }
+  });
 });


### PR DESCRIPTION
Previously errors would be swallowed inside a cycle and the benchmark would silently abort.